### PR TITLE
Firefox default NextDNS profile

### DIFF
--- a/encrypted-dns
+++ b/encrypted-dns
@@ -295,7 +295,7 @@ security-filter-dns.cleanbrowsing.org
 security.cloudflare-dns.com
 sg.gridns.xyz
 sky.rethinkdns.com
-trr.dns.nextdns.io/
+trr.dns.nextdns.io
 tls-dns-u.odvr.dns-oarc.net
 uncensored-dot.dnswarden.com
 unicast.censurfridns.dk

--- a/encrypted-dns
+++ b/encrypted-dns
@@ -231,6 +231,7 @@ fdns1.dismail.de
 fdns2.dismail.de
 fi.doh.dns.snopyta.org
 fi.dot.dns.snopyta.org
+firefox.dns.nextdns.io
 free.bravedns.com
 freedns.controld.com
 getdnsapi.net

--- a/encrypted-dns
+++ b/encrypted-dns
@@ -295,6 +295,7 @@ security-filter-dns.cleanbrowsing.org
 security.cloudflare-dns.com
 sg.gridns.xyz
 sky.rethinkdns.com
+trr.dns.nextdns.io/
 tls-dns-u.odvr.dns-oarc.net
 uncensored-dot.dnswarden.com
 unicast.censurfridns.dk


### PR DESCRIPTION
Add trr.dns.nextdns.io as it can be used to overrule current profile with restrictions on firefox.

@romaincointepas  - Fixes #3 