### PR TITLE
Block Chrome NextDNS Default DoH

### DIFF
--- a/encrypted-dns
+++ b/encrypted-dns
@@ -26,6 +26,7 @@ blitz.ahadns.com
 bravedns.com
 canadianshield.cira.ca
 chrome.cloudflare-dns.com
+chromium.dns.nextdns.io
 cloudflare-dns.com
 cloudflare-gateway.com
 commons.host

--- a/encrypted-dns
+++ b/encrypted-dns
@@ -26,9 +26,9 @@ blitz.ahadns.com
 bravedns.com
 canadianshield.cira.ca
 chrome.cloudflare-dns.com
-chromium.dns.nextdns.io
 cloudflare-dns.com
 cloudflare-gateway.com
+chromium.dns.nextdns.io
 commons.host
 deic-lgb.anycast.censurfridns.dk
 deic-lgb.anycast.uncensoreddns.org


### PR DESCRIPTION
add chromium.dns.nextdns.io to block default NextDNS DoH in Chrome